### PR TITLE
Rename to `with_cfg.bzl`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,5 +1,5 @@
 module(
-    name = "fmeum_with_cfg",
+    name = "with_cfg.bzl",
     version = "0.0.0",
     compatibility_level = 1,
 )

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -1,6 +1,6 @@
-bazel_dep(name = "fmeum_with_cfg", version = "", repo_name = "with_cfg")
+bazel_dep(name = "with_cfg.bzl", version = "")
 local_path_override(
-    module_name = "fmeum_with_cfg",
+    module_name = "with_cfg.bzl",
     path = "..",
 )
 

--- a/examples/cc/defs.bzl
+++ b/examples/cc/defs.bzl
@@ -1,4 +1,4 @@
-load("@with_cfg//with_cfg:defs.bzl", "with_cfg")
+load("@with_cfg.bzl", "with_cfg")
 
 _builder = with_cfg(native.cc_test)
 _builder.extend(

--- a/examples/sh/defs.bzl
+++ b/examples/sh/defs.bzl
@@ -1,3 +1,3 @@
-load("@with_cfg//with_cfg:defs.bzl", "with_cfg")
+load("@with_cfg.bzl", "with_cfg")
 
 my_sh_test, _my_sh_test_ = with_cfg(native.sh_test).build()

--- a/with_cfg.bzl
+++ b/with_cfg.bzl
@@ -1,0 +1,3 @@
+load("//with_cfg:defs.bzl", _with_cfg = "with_cfg")
+
+with_cfg = _with_cfg

--- a/with_cfg/defs.bzl
+++ b/with_cfg/defs.bzl
@@ -1,3 +1,5 @@
 load("//with_cfg/private:with_cfg.bzl", _with_cfg = "with_cfg")
 
+visibility("//")
+
 with_cfg = _with_cfg


### PR DESCRIPTION
This allows users to load `with_cfg` via:

```starlark
load("@with_cfg.bzl", "with_cfg")
```